### PR TITLE
Fix hydraJobs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,8 @@
               nameValuePair "${n}-${name}" v
             else
               nameValuePair n v) s.${name})) { } (attrNames s);
+      isUnfree = licenses: any (l: !l.free or true) (toList licenses);
+      hasUnfreeLicense = attrs: attrs ? meta.license && isUnfree (attrs.meta.license);
 
     in eachDefaultSystem (system:
       let
@@ -142,9 +144,7 @@
         };
 
         checks = flattenTree intree-packages;
-        hydraJobs = filterAttrs
-          (_: v: !(hasAttrByPath [ "meta" "license" ] v) || v.meta.license.free)
-          checks;
+        hydraJobs = filterAttrs (_: v: !(hasUnfreeLicense v)) checks;
       }) // {
         overlay = final: prev: {
           nixos-cn = mapRecurseIntoAttrs (makePackageScope final);


### PR DESCRIPTION
Free licenses don't have the attribute `free`.

* https://github.com/NixOS/nixpkgs/blob/master/lib/licenses.nix
* https://github.com/NixOS/nixpkgs/blob/e9dd32f58e6fac78ca8b981f6317e204dfde0638/pkgs/stdenv/generic/check-meta.nix#L50-L54

```shell
$ nix flake show "github:nixos-cn/flakes"
github:nixos-cn/flakes/f6f9c72b790954b1101c44759f78e8109ac2c8ca
├───apps
│   ├───aarch64-linux
│   │   ├───re-export-hash: app
│   │   └───update-lock: app
...
│       ├───"vim-packages/vim-vala": derivation 'vimplugin-vim-vala'
│       └───wine-wechat: derivation 'wechat'
├───hydraJobs
error: attribute 'free' missing

       at /nix/store/j34myrasybjxmn0yz7v6ji7krkwc9ng5-source/flake.nix:146:61:

          145|         hydraJobs = filterAttrs
          146|           (_: v: !(hasAttrByPath [ "meta" "license" ] v) || v.meta.license.free)
             |                                                             ^
          147|           checks;
(use '--show-trace' to show detailed location information)
```