### PR TITLE
Add missing buildInputs for netease-cloud-music

### DIFF
--- a/packages/netease-cloud-music/default.nix
+++ b/packages/netease-cloud-music/default.nix
@@ -1,12 +1,12 @@
 { alsaLib, autoPatchelfHook, dpkg, e2fsprogs, fetchurl, fontconfig, freetype
-, gdk-pixbuf, glib, harfbuzz, lib, libGL, libgpgerror, libusb, makeWrapper
+, gdk-pixbuf, glib, harfbuzz, lib, libdrm, libGL, libgpgerror, libusb, makeWrapper
 , p11-kit, pango, qt5, stdenv, xorg, zlib }:
 stdenv.mkDerivation rec {
   pname = "netease-cloud-music";
-  version = "1.2.0";
+  version = "1.2.1";
   src = fetchurl {
     url =
-      "http://d1.music.126.net/dmusic/netease-cloud-music_1.2.1_amd64_ubuntu_20190428.deb";
+      "http://d1.music.126.net/dmusic/netease-cloud-music_${version}_amd64_ubuntu_20190428.deb";
     sha256 = "1fzc5xb3h17jcdg8w8xliqx2372g0wrfkcj8kk3wihp688lg1s8y";
     curlOpts = "-A 'Mozilla/5.0'";
   };
@@ -22,6 +22,7 @@ stdenv.mkDerivation rec {
     gdk-pixbuf
     glib
     harfbuzz
+    libdrm
     libGL
     libgpgerror
     libusb
@@ -59,7 +60,7 @@ stdenv.mkDerivation rec {
     description = "Client for Netease Cloud Music service";
     homepage = "https://music.163.com";
     platforms = [ "x86_64-linux" ];
-    maintainers = [ stdenv.lib.maintainers.mlatus ];
-    license = stdenv.lib.licenses.unfree;
+    maintainers = [ lib.maintainers.mlatus ];
+    license = lib.licenses.unfree;
   };
 }


### PR DESCRIPTION
```shell
$ nix build "github:nixos-cn/flakes#netease-cloud-music"
trace: Warning: `stdenv.lib` is deprecated and will be removed in the next release. Please use `lib` instead. For more information see https://github.com/NixOS/nixpkgs/issues/108938
error: builder for '/nix/store/iqqh6hd3j5khfi7zyh8x5za94hi5fhq1-netease-cloud-music-1.2.0.drv' failed with exit code 1;
       last 10 log lines:
       >   libXtst.so.6 -> found: /nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs/libXtst.so.6
       >   libQt5Network.so.5 -> found: /nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs/libQt5Network.so.5
       >   libQt5Gui.so.5 -> found: /nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs/libQt5Gui.so.5
       >   libQt5DBus.so.5 -> found: /nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs/libQt5DBus.so.5
       >   libQt5Core.so.5 -> found: /nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs/libQt5Core.so.5
       >   libz.so.1 -> found: /nix/store/65ys3k6gn2s27apky0a0la7wryg3az9q-zlib-1.2.11/lib/libz.so.1
       >   libstdc++.so.6 -> found: /nix/store/54klr10i53jdfgn7322mzgza6wsai0q8-gcc-10.3.0-lib/lib/libstdc++.so.6
       > setting RPATH to: /nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs:/nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs:/nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs:/nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs:/nix/store/9wcp4vp7s3nd5y9rzz9m7a7da45h2f8p-fontconfig-2.13.92-lib/lib:/nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs:/nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs:/nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs:/nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs:/nix/store/j1ah55qaqg5cfsg21y5ai55gdblkxh9c-libX11-1.7.0/lib:/nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs:/nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs:/nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs:/nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs:/nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs:/nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/libs:/nix/store/65ys3k6gn2s27apky0a0la7wryg3az9q-zlib-1.2.11/lib:/nix/store/54klr10i53jdfgn7322mzgza6wsai0q8-gcc-10.3.0-lib/lib
       > autoPatchelfHook could not satisfy dependency libdrm.so.2 wanted by /nix/store/p96n5ss1wcydaqkfb121xrih3mf175nv-netease-cloud-music-1.2.0/lib/netease-cloud-music/plugins/platforms/libqlinuxfb.so
       > Add the missing dependencies to the build inputs or set autoPatchelfIgnoreMissingDeps=true
       For full logs, run 'nix log /nix/store/iqqh6hd3j5khfi7zyh8x5za94hi5fhq1-netease-cloud-music-1.2.0.drv'.
```