### PR TITLE
flake: separate overlay from flake 

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,51 @@
+self: super:
+with builtins;
+with self.lib;
+let
+  mapRecurseIntoAttrs' = key: s:
+    if any (k: k == key) (attrNames s) then
+      s
+    else
+      mapAttrs (k: v:
+        if !isAttrs v || isDerivation v then
+          v
+        else
+          mapRecurseIntoAttrs' k v) (recurseIntoAttrs s);
+  mapRecurseIntoAttrs = mapRecurseIntoAttrs' null;
+  listNixFilesRecursive = dir:
+    flatten (mapAttrsToList (name: type:
+      let path = dir + "/${name}";
+      in if type == "directory" then
+        if pathExists (dir + "/${name}/default.nix") then
+          path
+        else
+          listNixFilesRecursive path
+      else if hasSuffix ".nix" name then
+        path
+      else
+        [ ]) (readDir dir));
+  getPackages = f: dir:
+    let
+      getAttrPathPrefix = target:
+        filter (p: p != "") (splitString "/"
+          (removePrefix (toString dir) (toString (dirOf target))));
+      getName = target:
+        let baseName = baseNameOf target;
+        in if hasSuffix ".nix" baseName then
+          removeSuffix ".nix" baseName
+        else
+          baseName;
+      getAttrPath = target:
+        ((getAttrPathPrefix target) ++ [ (getName target) ]);
+    in foldl (set: target:
+      recursiveUpdate set (setAttrByPath (getAttrPath target) (f target)))
+    { } (listNixFilesRecursive dir);
+  makePackageSet = f: getPackages f ./packages;
+  makePackageScope = pkgs:
+    makeScope pkgs.newScope (self:
+      (makePackageSet
+        (n: self.callPackage n { } // { __definition_entry = n; })));
+in
+{
+  nixos-cn = mapRecurseIntoAttrs (makePackageScope self);
+}

--- a/flake.nix
+++ b/flake.nix
@@ -201,9 +201,7 @@
         checks = flattenTree intree-packages;
         hydraJobs = filterAttrs (_: v: !(hasUnfreeLicense v)) checks;
       }) // {
-        overlay = final: prev: {
-          nixos-cn = mapRecurseIntoAttrs (makePackageScope final);
-        };
+        overlay = final: prev: import ./. final prev;
         nixosModules.nixos-cn = { ... }: {
           nixpkgs.overlays = [ self.overlay ];
           imports = listNixFilesRecursive ./modules;


### PR DESCRIPTION
我没有删去 flake 里同样重复定义的函数，有人清理一下就好了，比如拆个单独的 lib 出来。

我没试 flake 下面的修改（因为我没用

overlay 这个我用 `(import <nixpkgs> { overlays = [ (import ./.) ]; }).nixos-cn` 试了一下，是正常的